### PR TITLE
prevent memory leak by calling is_FreeImageMem after is_AllocImageMem

### DIFF
--- a/camera_interfacing/IDS_uEye_camera.cpp
+++ b/camera_interfacing/IDS_uEye_camera.cpp
@@ -102,7 +102,8 @@ Mat getFrame(HIDS* hCam, int width, int height, cv::Mat& mat) {
 		cout << "Image data could not be read from memory!" << endl;
 	}
 	memcpy(mat.ptr(), pMem_b, mat.cols * mat.rows);
-
+	is_FreeImageMem(*hCam, pMem, memID)
+	
     	return mat;
 }
 


### PR DESCRIPTION
is_AllocImageMem allocates memory in the heap.
The memory is not freed in the function.
is_FreeImageMem makes sure the allocaded memory is freed.